### PR TITLE
5.30/inspection cycle length/week month

### DIFF
--- a/client/src/components/AssignedReportCard/index.jsx
+++ b/client/src/components/AssignedReportCard/index.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { dateToLocale } from '../../utils/dateTimeTools.js';
+import { dateToLocale, dateTimeToLocale } from '../../utils/dateTimeTools.js';
 
 function AssignedReportCard({ id, name, client, location, address, cycle, lastInspected, dateTimeProperties, completed }) {
     
@@ -13,8 +13,8 @@ function AssignedReportCard({ id, name, client, location, address, cycle, lastIn
                 <p><span className="font-bold">Location: </span>{location}</p>
                 <p>{address}</p>
                 <br></br>
-                <p><span className="font-bold">Inspection Cycle: </span>{cycle} minutes</p>
-                <p><span className="font-bold">Last Inspected: </span>{dateToLocale(lastInspected)}</p>
+                <p><span className="font-bold">Inspection Cycle: </span>{cycle}</p>
+                <p><span className="font-bold">Last Inspected: </span>{dateTimeToLocale(lastInspected)}</p>
                 <br></br>
                 <p className="font-bold">Due For Next Inspection By:</p> 
                 <p>{dateToLocale(upcomingDueDate)}</p>

--- a/client/src/components/RecentReportCard/index.jsx
+++ b/client/src/components/RecentReportCard/index.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { dateToLocale } from '../../utils/dateTimeTools.js';
+import { dateToLocale, dateTimeToLocale } from '../../utils/dateTimeTools.js';
 
 function RecentReportCard({ id, name, client, location, cycle, inspectionDate, results, generalComments, assignedStaff }) {
     let renderResults = [];
@@ -25,7 +25,7 @@ function RecentReportCard({ id, name, client, location, cycle, inspectionDate, r
                 <p><span className="font-bold">Client: </span>{client}</p>
                 <p><span className="font-bold">Location: </span>{location}</p>
                 <br></br>
-                <p><span className="font-bold">Inspection Date: </span>{dateToLocale(inspectionDate)}</p>
+                <p><span className="font-bold">Inspection Date: </span>{dateTimeToLocale(inspectionDate)}</p>
                 <p><span className="font-bold">Inspected By: </span>{assignedStaff}</p>
                 <br></br>
                 <p className="card-title">Results Summary:</p>

--- a/client/src/pages/Inspection.jsx
+++ b/client/src/pages/Inspection.jsx
@@ -8,7 +8,7 @@ import { ROOM_INFO_BY_REPORT_ID, RESULT_DATA_BY_REPORT_ID } from '../utils/queri
 import { useMutation } from '@apollo/client';
 import { DELETE_REPORT_RESULTS, ADD_RESULT, SUBMIT_REPORT, UPDATE_ROOM_LAST_INSPECTION_DATE } from '../utils/mutations';
 
-import { dateToLocale } from '../utils/dateTimeTools.js';
+import { dateToLocale, dateTimeToLocale } from '../utils/dateTimeTools.js';
 
 function Inspection() {
 
@@ -274,11 +274,11 @@ function Inspection() {
                         <p><span className="font-bold">Location: </span>{locationName}</p>
                         <p>{address}</p>
                         <br></br>
-                        <p><span className="font-bold">Inspection Cycle: </span>{cycle} minutes</p>
+                        <p><span className="font-bold">Inspection Cycle: </span>{cycle}</p>
                         {!updateStatus ? (
-                            <p><span className="font-bold">Last Inspected: </span>{dateToLocale(lastInspected)}</p>
+                            <p><span className="font-bold">Last Inspected: </span>{dateTimeToLocale(lastInspected)}</p>
                         ) : (
-                            <p><span className="font-bold">Inspection Date: </span>{dateToLocale(inspectionDate)}</p>
+                            <p><span className="font-bold">Inspection Date: </span>{dateTimeToLocale(inspectionDate)}</p>
                         )}
                         <br></br>
                         {equipment.map((equipmentItem) => (

--- a/client/src/utils/dateTimeTools.js
+++ b/client/src/utils/dateTimeTools.js
@@ -6,6 +6,14 @@ import { differenceInMinutes } from 'date-fns';
 export const dateToLocale = (time) => {
   const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const zonedDate = toZonedTime(time, userTimeZone);
+  const formattedDate = format(zonedDate, 'P', { timeZone: userTimeZone });
+
+  return formattedDate;
+};
+
+export const dateTimeToLocale = (time) => {
+  const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const zonedDate = toZonedTime(time, userTimeZone);
   const formattedDate = format(zonedDate, 'Pp', { timeZone: userTimeZone });
 
   return formattedDate;

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -34,7 +34,7 @@ scalar DateTime
     location: Location
     equipment: [Equipment]
     lastInspectionDate: DateTime
-    inspectionCycleLength: Int
+    inspectionCycleLength: String!
     dateTimeProperties: DateTimeProperties
   }
 
@@ -145,8 +145,8 @@ scalar DateTime
     deleteReportResults(reportId: ID!): DeleteReportResultsResponse
     submitReport(reportId: ID!, results: [ID]!, generalComments: String, inspectionDate: DateTime!): Report
     updateRoomLastInspectionDate(roomId: ID!, lastInspectionDate: DateTime!): Room
-    addRoom(locationId: ID, roomName: String!, inspectionCycleLength: Int, equipment: [String]): Room
-    editRoom(roomId: ID, roomName: String, inspectionCycleLength: Int, equipment: [String]): Room
+    addRoom(locationId: ID, roomName: String!, inspectionCycleLength: String, equipment: [String]): Room
+    editRoom(roomId: ID, roomName: String, inspectionCycleLength: String, equipment: [String]): Room
     editLocation(locationId: ID, locationName: String, address: String, accessInstructions: String): Location
     editClient(clientId: ID, businessName: String, contactName: String, contactEmail: String): Client
   }

--- a/server/seeders/roomSeeds.json
+++ b/server/seeders/roomSeeds.json
@@ -2,116 +2,116 @@
     {
         "roomName": "3301",
         "locationString": "C3PO Town Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Daily"
     },
     {
         "roomName": "3302",
         "locationString": "C3PO Town Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "3303",
         "locationString": "C3PO Town Hall",
-        "inspectionCycleLength": "5"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "3304",
         "locationString": "C3PO Town Hall",
-        "inspectionCycleLength": "5"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "Auditorium",
         "locationString": "C3PO Town Hall",
-        "inspectionCycleLength": "5"
+        "inspectionCycleLength": "Daily"
     },
     {
         "roomName": "VC Lab 1",
         "locationString": "R2D2 Laboratory",
-        "inspectionCycleLength": "15"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "VC Lab 2",
         "locationString": "R2D2 Laboratory",
-        "inspectionCycleLength": "15"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "51A",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "51B",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "51C",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "53A",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "53B",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "53C",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "53D",
         "locationString": "Peterson Hall",
-        "inspectionCycleLength": "10"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "Jefferson",
         "locationString": "Office Quad A",
-        "inspectionCycleLength": "30"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "Adams",
         "locationString": "Office Quad A",
-        "inspectionCycleLength": "30"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "Washington",
         "locationString": "Office Quad A",
-        "inspectionCycleLength": "30"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "Monroe",
         "locationString": "Office Quad A",
-        "inspectionCycleLength": "30"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "Divisible Room A",
         "locationString": "West Bay Building",
-        "inspectionCycleLength": "45"
+        "inspectionCycleLength": "Daily"
     },
     {
         "roomName": "Divisible Room B",
         "locationString": "West Bay Building",
-        "inspectionCycleLength": "45"
+        "inspectionCycleLength": "Daily"
     },
     {
         "roomName": "Cafeteria For You",
         "locationString": "West Bay Building",
-        "inspectionCycleLength": "60"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "5606F",
         "locationString": "West Bay Building",
-        "inspectionCycleLength": "45"
+        "inspectionCycleLength": "Monthly"
     },
     {
         "roomName": "5606G",
         "locationString": "West Bay Building",
-        "inspectionCycleLength": "45"
+        "inspectionCycleLength": "Monthly"
     }
 ]

--- a/server/seeders/roomSeeds.json
+++ b/server/seeders/roomSeeds.json
@@ -2,7 +2,7 @@
     {
         "roomName": "3301",
         "locationString": "C3PO Town Hall",
-        "inspectionCycleLength": "Daily"
+        "inspectionCycleLength": "Weekly"
     },
     {
         "roomName": "3302",


### PR DESCRIPTION
Updated Room model to use cycle lengths of daily, weekly, and monthly instead of minutes.  

-Changed model InspectionCycleLength to be a string and update typedefs
-Updated virtual returning dateTimeProperties object to reflect change in cycles
-Added new DateTimeTool utility to provide flexibility if date and time are rendered on the page or if just the date