### PR TITLE
6.1/add room/adding refetch

### DIFF
--- a/client/src/components/UpdateClientForm/LocationRooms.jsx
+++ b/client/src/components/UpdateClientForm/LocationRooms.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useQuery } from "@apollo/client";
 
 
@@ -7,8 +7,12 @@ import EditRoom from "./EditRoom";
 import AddRoomForm from "../AddRoomForm";
 
 const LocationRooms = ({locations, locationId}) => {
-    const { loading, error, data } = useQuery( QUERY_ROOM );
+    const { loading, error, data, refetch } = useQuery( QUERY_ROOM );
     const [ editRoom, setEditRoom] = useState(null);
+
+    useEffect(() => {
+        refetch();
+    }, []);
 
     if (loading) {
         return <div>Loading...</div>;


### PR DESCRIPTION
import React, { useState, useEffect } from "react";
import { useQuery } from "@apollo/client";


import { QUERY_ROOM } from "../../utils/queries";
import EditRoom from "./EditRoom";
import AddRoomForm from "../AddRoomForm";

const LocationRooms = ({locations, locationId}) => {
    const { loading, error, data, refetch } = useQuery( QUERY_ROOM );
    const [ editRoom, setEditRoom] = useState(null);

    useEffect(() => {
        refetch();
    }, []);

    if (loading) {
        return <div>Loading...</div>;
    }